### PR TITLE
added eval command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,24 @@
 module github.com/unitoftime/nootbot
 
 go 1.18
+
+require (
+	github.com/jomy10/nootlang v0.0.0-20220520084025-438989030225
+	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	google.golang.org/api v0.80.0
+)
+
+require (
+	cloud.google.com/go/compute v1.6.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 // indirect
+	google.golang.org/grpc v1.46.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+)

--- a/main.go
+++ b/main.go
@@ -119,6 +119,10 @@ func (n *Noot) Listen() {
 				Name:    "!recursion",
 				Handler: RecursionCommander{},
 			},
+			Command{
+				Name:    "!eval",
+				Handler: NootlangCommander{},
+			},
 		}
 
 		for _, item := range resp.Items {

--- a/nootlang_interpreter.go
+++ b/nootlang_interpreter.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jomy10/nootlang/interpreter"
+	"github.com/jomy10/nootlang/parser"
+)
+
+type NootlangCommander struct{}
+
+func (c NootlangCommander) Handle(n *Noot, msg Message) {
+	str := msg.Parsed.Postfix
+
+	tokens, err := parser.Tokenize(str)
+	if err != nil {
+		n.SendMessage(fmt.Sprintf("Error while tokenizing source code: %s", err))
+	}
+
+	nodes, err := parser.Parse(tokens)
+	if err != nil {
+		n.SendMessage(fmt.Sprintf("Error while parsing source code: %s", err))
+	}
+
+	stdout := make(chan string)
+	stderr := make(chan string)
+	eop := make(chan int, 1)
+
+	defer close(stdout)
+	defer close(stderr)
+	defer close(eop)
+
+	go interpreter.Interpret(nodes, stdout, stderr, eop)
+	go outHandler(n, stdout)
+	go outHandler(n, stderr)
+
+	exitCode := <-eop
+	time.Sleep(2 * time.Millisecond)
+	fmt.Printf("Noot program exited with exit code %s\n", exitCode)
+}
+
+func outHandler(n *Noot, out chan string) {
+	n.SendMessage(<-out)
+}


### PR DESCRIPTION
Added the eval command, which executes the [nootlang](https://github.com/Jomy10/nootlang) code on the right side.

Currently nootlang supports assignments:
```
a := 5
```

and print statements (only with integer literatls):
```
print(5)
```
