### PR TITLE
Handle message edits

### DIFF
--- a/api/discord.go
+++ b/api/discord.go
@@ -36,11 +36,49 @@ func (d *Discord) Listen() {
 	}
 
 	d.session.AddHandler(d.handleMessages)
+	d.session.AddHandler(d.handleMessageUpdates)
 }
 
 // Handles MessageCreate events
 func (d *Discord) handleMessages(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// Ignore all messages created by the bot itself
+	if m.Author.ID == s.State.User.ID {
+		return
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Println("Recovering from panic: ", r)
+			}
+		}()
+
+		for _, command := range d.commands {
+			prefix, postfix, found := strings.Cut(m.Content, command.Name)
+			if !found {
+				continue
+			}
+
+			message := cmd.Message{
+				Id: m.ID,
+				Author: cmd.User{
+					Id:   m.Author.ID,
+					Name: m.Author.Username,
+				},
+				Parsed: cmd.ParsedMessage{
+					Command: command.Name,
+					Prefix:  prefix,
+					Postfix: postfix,
+				},
+			}
+
+			nooter := cmd.NewDiscordNooter(m.ChannelID, d.session)
+			command.Handler.Handle(nooter, message)
+		}
+	}()
+}
+func (d *Discord) handleMessageUpdates(s *discordgo.Session, m *discordgo.MessageUpdate) {
+	// Ignore all messages edited by the bot itself
 	if m.Author.ID == s.State.User.ID {
 		return
 	}


### PR DESCRIPTION
Small change to make NootBot listen to edited messages so that you can edit commands instead of recreating them.